### PR TITLE
Fix setFPS NullPointerException

### DIFF
--- a/library/src/main/java/xyz/matteobattilana/library/WeatherView.java
+++ b/library/src/main/java/xyz/matteobattilana/library/WeatherView.java
@@ -183,9 +183,11 @@ public class WeatherView extends View {
                 break;
         }
 
-        mParticleSystem.setFPS(getFPS());
 
         if (mParticleSystem != null) {
+            
+            mParticleSystem.setFPS(getFPS());
+            
             this.post(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
Moved mParticleSystem.setFPS(getFPS()); into the null check, because if WeatherView is used with SUN option first, mParticleSystem is null, and mParticleSystem.setFPS(getFPS());  gives a NullPointerException.